### PR TITLE
Fix Pods and add github action

### DIFF
--- a/.github/workflows/publish-swift-package.yml
+++ b/.github/workflows/publish-swift-package.yml
@@ -1,0 +1,74 @@
+name: Publish Swift Bindings
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'LWK repo release (MAJOR.MINOR.PATCH)'
+        required: true
+        type: string
+
+jobs:
+  build-tag-release:
+    name: Build, tag, and release the LWK SDK Swift bindings
+    runs-on: macos-14
+    steps:
+      - name: Setup rust toolchain
+        uses: dtolnay/rust-toolchain@1.75.0
+        with:
+          targets: x86_64-apple-ios,aarch64-apple-ios,aarch64-apple-ios-sim
+      - name: Setup just
+        uses: extractions/setup-just@v1
+        with:
+          just-version: 1.5.0  # optional semver specification, otherwise latest
+      - name: Checkout lwk-swift repo
+        uses: actions/checkout@v3
+        with:
+          repository: Blockstream/lwk-swift
+          ref: main
+      - name: Checkout lwk repo
+        uses: actions/checkout@v3
+        with:
+          repository: Blockstream/lwk
+          ref: ${{ inputs.version }}
+          path: build
+      - name: Build Swift bindings
+        working-directory: build
+        run: just swift
+      - name: Compress XCFramework
+        working-directory: build
+        run: |
+          zip -9 -r target/lwkFFI.xcframework.zip target/lwkFFI.xcframework
+          echo "XCF_CHECKSUM=`swift package compute-checksum lwkFFI.xcframework.zip`" >> $GITHUB_ENV
+      - name: LS
+        run: ls
+      - name: Update Swift Package definition
+        run: |
+          sed -i '' 's#.binaryTarget(name: "lwkFFI".*$#.binaryTarget(name: "lwkFFI", url: "https://github.com/Blockstream/lwk-swift/releases/download/${{ inputs.version }}/lwkFFI.xcframework.zip", checksum: "${{ env.XCF_CHECKSUM }}"),#' Package.swift
+      - name: Update Cocoapods definitions
+        run: |
+          sed  -i '' 's/^.\{4\}spec.version.*$/    spec.version                = "${{ inputs.version }}"/g' lwkFFI.podspec
+          sed  -i '' 's/^.\{4\}spec.version.*$/    spec.version                = "${{ inputs.version }}"/g' LiquidWalletKit.podspec
+      - name: Tag the Swift bindings
+        run: |
+          git add Package.swift
+          git add Sources
+          git add lwkFFI.podspec
+          git add LiquidWalletKit.podspec
+          git commit -m "Bump Liquid Wallet Kit to version ${{ inputs.version }}"
+          git push
+          git tag ${{ inputs.version }} -m "${{ inputs.version }}"
+          git push --tags
+      - name: Release and attach XCFramework binary artifact
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "build/target/lwkFFI.xcframework.zip"
+          tag: ${{ inputs.version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ inputs.version }}
+          prerelease: true
+      - name: Push update to Cocoapods trunk
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{secrets.COCOAPODS_TRUNK_TOKEN}}
+        run: |
+          pod trunk push lwkFFI.podspec --allow-warnings
+          pod trunk push LiquidWalletKit.podspec --allow-warnings --synchronous

--- a/LiquidWalletKit.podspec
+++ b/LiquidWalletKit.podspec
@@ -4,9 +4,10 @@ Pod::Spec.new do |spec|
     spec.license                = { :type => "MIT OR BSD-2-Clause" }
     spec.summary                = "Swift bindings to the Liquid Wallet Kit"
     spec.homepage               = "https://blockstream.com"
+    spec.authors                = { "Riccardo Casatta" => "riccardo@casatta.it", "Luca Vaccaro" => "me@lvaccaro.com" }
     spec.documentation_url      = "https://docs.rs/lwk_bindings"
-    spec.source                 = { :git => 'https://github.com/blockstream/lwk-swift.git', :tag => spec.version }
-    spec.ios.deployment_target  = "14.0"
+    spec.source                 = { :git => 'https://github.com/Blockstream/lwk-swift.git', :tag => spec.version }
+    spec.ios.deployment_target  = "13.0"
     spec.source_files           = [
       "Sources/LiquidWalletKit/*.swift", 
       "Sources/LiquidWalletKit/**/*.swift"

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "lwk_bindings",
     platforms: [
         .macOS(.v12),
-        .iOS(.v11),
+        .iOS(.v13),
     ],
     products: [
         .library(name: "LiquidWalletKit", targets: ["lwkFFI", "LiquidWalletKit"]),

--- a/lwkFFI.podspec
+++ b/lwkFFI.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |spec|
     spec.license                = { :type => "MIT OR BSD-2-Clause" }
     spec.summary                = "Low-level bindings to the Liquid Wallet Kit Rust API"
     spec.homepage               = "https://blockstream.com"
-    spec.authors                = { "Blockstream" }
+    spec.authors                = { "Riccardo Casatta" => "riccardo@casatta.it", "Luca Vaccaro" => "me@lvaccaro.com" }
     spec.documentation_url      = "https://docs.rs/lwk_bindings"
     spec.source                 = { :http => "https://github.com/Blockstream/lwk-swift/releases/download/test/lwkFFI.xcframework.zip" }
     spec.ios.deployment_target  = "14.0"

--- a/lwkFFI.podspec
+++ b/lwkFFI.podspec
@@ -7,6 +7,6 @@ Pod::Spec.new do |spec|
     spec.authors                = { "Riccardo Casatta" => "riccardo@casatta.it", "Luca Vaccaro" => "me@lvaccaro.com" }
     spec.documentation_url      = "https://docs.rs/lwk_bindings"
     spec.source                 = { :http => "https://github.com/Blockstream/lwk-swift/releases/download/test/lwkFFI.xcframework.zip" }
-    spec.ios.deployment_target  = "14.0"
+    spec.ios.deployment_target  = "13.0"
     spec.vendored_frameworks    = "lwkFFI.xcframework"
   end


### PR DESCRIPTION
- fix pod specs and preparing for cocoapods publishing
- add github action for version upgrading
- decrease minimum supported iOS version to 13. This is a requirement for wrapping it into react native framework

Github action does :
1. fetch & build [lwk](https://github.com/Blockstream/lwk) 
2. upgrade spec and swift files, with the same version number of the lwk tag reference, and upgrade the xcframework path and hash. Need a secret `GITHUB_TOKEN`
3. publish the cocoapods spec in cocoapods mirror. Need a secret `COCOAPODS_TRUNK_TOKEN`