### PR TITLE
copy sources for swift interface

### DIFF
--- a/.github/workflows/publish-swift-package.yml
+++ b/.github/workflows/publish-swift-package.yml
@@ -57,6 +57,9 @@ jobs:
           envsubst <templates/lwkFFI.podspec >lwkFFI.podspec
           envsubst <templates/LiquidWalletKit.podspec >LiquidWalletKit.podspec
           envsubst <templates/Package.swift >Package.swift
+      - name: Copy sources
+        run: |
+          cp build/target/swift/lwk.swift Sources/LiquidWalletKit/LiquidWalletKit.swift
       - name: Tag the Swift bindings
         run: |
           git add Package.swift Sources lwkFFI.podspec LiquidWalletKit.podspec


### PR DESCRIPTION
update `Source/LiquidWalletKit/LiquidWalletKit.swift` file from the `build/target/swift` folder to the project folder before submit a new release.

bug: the `LiquidWalletKit.swift` is not updated by github action