### PR TITLE
ci: update artifact checksum to

### DIFF
--- a/templates/Package.swift
+++ b/templates/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "LiquidWalletKit", targets: ["lwkFFI", "LiquidWalletKit"]),
     ],
     targets: [
-        .binaryTarget(name: "lwkFFI", url: "https://github.com/Blockstream/lwk-swift/releases/download/${VERSION}/lwkFFI.xcframework.zip", checksum: "${CHECKSUM}"),
+        .binaryTarget(name: "lwkFFI", url: "https://github.com/Blockstream/lwk-swift/releases/download/${VERSION}/lwkFFI.xcframework.zip", checksum: "${XCF_CHECKSUM}"),
         .target(name: "LiquidWalletKit", dependencies: ["lwkFFI"]),
     ]
 )


### PR DESCRIPTION
Fix to align checksum variable names.

#### Issue
Right now, github action build calculates artifact checksum in `XCF_CHECKSUM` 
https://github.com/Blockstream/lwk-swift/blob/c692d58c28f096c43afc31143b4a0bd4533aba67/.github/workflows/publish-swift-package.yml#L51

But `Package.swift` uses the wrong name variable `CHECKSUM`
https://github.com/Blockstream/lwk-swift/blob/c692d58c28f096c43afc31143b4a0bd4533aba67/templates/Package.swift#L16

