### PR TITLE
Add MARKETING_VERSION to project.yml

### DIFF
--- a/.github/workflows/publish-swift-package.yml
+++ b/.github/workflows/publish-swift-package.yml
@@ -42,6 +42,12 @@ jobs:
           ref: ${{ inputs.version }}
           path: build
       - uses: Swatinem/rust-cache@v2
+      - name: Add MARKETING_VERSION to project.yml
+        working-directory: build/lwk_bindings/swift
+        run: |
+          brew install yq
+          yq e '.targets.lwkFFI.settings.MARKETING_VERSION = env(VERSION)' -i project.yml
+          yq e '.targets.lwkFFI.settings.CURRENT_PROJECT_VERSION = "1"' -i project.yml
       - name: Build Swift bindings
         working-directory: build
         run: just swift


### PR DESCRIPTION
Apple requires a version number in format x.x.x for all framework included in an application at appstore submission.

Add version number properties in the LWK project.yml:

- `MARKETING_VERSION`: The user-facing version x.x.x (add `CFBundleShortVersionString` into `Info.plist` file) 
- `CURRENT_PROJECT_VERSION`: The build number xx (add `CFBundleVersion` into `Info.plist` file)
